### PR TITLE
Update `work` struct fields. `company`=>`name`, `website`=>`url`

### DIFF
--- a/resume.hbs
+++ b/resume.hbs
@@ -186,12 +186,12 @@
                       <a class="anchor-link item-anchor" href="#{{itemID 'experience' @index ../resume.work.length}}">#</a>
                       <h4>
                         <strong>{{position}}</strong>
-                        {{~#if company~}}
+                        {{~#if name~}}
                           ,&nbsp;
-                          {{#if website}}
-                            <a href="{{website}}"  target="_blank" rel="noreferrer noopener" itemprop="url"><span itemprop="name">{{company}}</span></a>
+                          {{#if url}}
+                            <a href="{{url}}"  target="_blank" rel="noreferrer noopener" itemprop="url"><span itemprop="name">{{name}}</span></a>
                           {{else}}
-                            <span itemprop="name">{{company}}</span>
+                            <span itemprop="name">{{name}}</span>
                           {{/if}}
                         {{/if}}
                       </h4>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The schema has different fields for `work` than what are referenced in the `resume.hbs` file. This prevented company name from rendering.

## Related Issues
Fixes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change allows the company name under the `work` section to be rendered-- without this change, the company name would be omitted.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested this by making the change and running the command below and verifying that before the change the company name was missing and after the change the company name was visible. I also tested the combination of name with url and name without url and verified the hyperlinking worked.
```
resume-cli serve --theme jsonresume-theme-eloquent-mod
```
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
